### PR TITLE
jsexpr template literal

### DIFF
--- a/packages/delisp-core/package.json
+++ b/packages/delisp-core/package.json
@@ -18,9 +18,11 @@
     "@delisp/runtime": "^0.2.0",
     "@types/debug": "^4.1.4",
     "debug": "^4.1.0",
-    "escodegen": "^1.11.1"
+    "escodegen": "^1.11.1",
+    "esprima": "^4.0.1"
   },
   "devDependencies": {
+    "@types/esprima": "^4.0.2",
     "@types/estree": "^0.0.39"
   }
 }

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -26,7 +26,7 @@ import {
 import { printType } from "./type-printer";
 
 import {
-  methodCall,
+  jsexpr,
   literal,
   identifier,
   primitiveCall,
@@ -317,11 +317,8 @@ function compileRecord(
     )
   };
   if (expr.node.extends) {
-    return methodCall({ type: "Identifier", name: "Object" }, "assign", [
-      { type: "ObjectExpression", properties: [] },
-      compile(expr.node.extends, env, false),
-      newObj
-    ]);
+    const extending = compile(expr.node.extends, env, false);
+    return jsexpr`Object.assign({}, ${extending}, ${newObj})`;
   } else {
     return newObj;
   }

--- a/packages/delisp-core/src/compiler/estree-utils.spec.ts
+++ b/packages/delisp-core/src/compiler/estree-utils.spec.ts
@@ -1,0 +1,58 @@
+import * as JS from "estree";
+import { jsexpr } from "./estree-utils";
+
+const literal = (value: any): any => ({ type: "Literal", value });
+
+describe("JS AST Template literals", () => {
+  test("should read basic expressions", () => {
+    const ast = jsexpr`3`;
+    expect(ast).toHaveProperty("type", "Literal");
+    expect(ast).toHaveProperty("value", 3);
+  });
+
+  test("should replace expressions with placeholders", () => {
+    const ast = jsexpr`x + ${{ type: "Literal", value: 3 }}`;
+    expect(ast).toMatchObject({
+      type: "BinaryExpression",
+      left: {
+        type: "Identifier",
+        name: "x"
+      },
+      right: literal(3)
+    });
+  });
+
+  test("should replace multiple expressions", () => {
+    const ast = jsexpr`${literal(42)} + ${literal(24)}`;
+    expect(ast).toMatchObject({
+      type: "BinaryExpression",
+      left: literal(42),
+      right: literal(24)
+    });
+  });
+
+  test("should replace placeholders inside argument list", () => {
+    const ast = jsexpr`f(1, ${literal(42)})`;
+    expect(ast).toMatchObject({
+      type: "CallExpression",
+      arguments: [{ type: "Literal", value: 1 }, { type: "Literal", value: 42 }]
+    });
+  });
+
+  test("should replace placeholders inside argument list", () => {
+    const ast = jsexpr`f(1, ${literal(42)})`;
+    expect(ast).toMatchObject({
+      type: "CallExpression",
+      arguments: [{ type: "Literal", value: 1 }, { type: "Literal", value: 42 }]
+    });
+  });
+
+  test("should spread placeholders with array values inside an argument list", () => {
+    const args: JS.Expression[] = [literal(1), literal(42)];
+    const ast = jsexpr`f(${args})`;
+    expect(ast).toMatchObject({
+      type: "CallExpression",
+      arguments: [{ type: "Literal", value: 1 }, { type: "Literal", value: 42 }]
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,7 +1047,14 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.4.tgz#56eec47706f0fd0b7c694eae2f3172e6b0b769da"
   integrity sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==
 
-"@types/estree@^0.0.39":
+"@types/esprima@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/esprima/-/esprima-4.0.2.tgz#0303602d0644086d4802635d7abc9ac0eec57207"
+  integrity sha512-DKqdyuy7Go7ir6iKhZ0jUvgt/h9Q5zb9xS+fLeeXD2QSHv8gC6TimgujBBGfw8dHrpx4+u2HlMv7pkYOOfuUqg==
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*", "@types/estree@^0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
@@ -2458,7 +2465,7 @@ esprima@^3.1.3:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==


### PR DESCRIPTION
This implements #92 .

However I have noticed that the template function is not very useful unfortunately.. it's too fragile.  The placeholders implies that if you use something like

```
jsexpr`x => ${x}`
```

then it won't be converted to a block statement when necessary. Because not only the content needs to change, also the function itself needs to change the `expression: true|false` attribute.

I'm sure we can add lot of rules ot make it work,  but I think more helpers is a preferable approach.

In case case, here it is for reference.