### PR TITLE
Modified lenses

### DIFF
--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -121,7 +121,7 @@ describe("Evaluation", () => {
       expect(evaluateString("{:x 2 :y 8}")).toEqual({ x: 2, y: 8 });
     });
     it("should access record fields", () => {
-      expect(evaluateString("(get :foo {:bar 3 :foo 5 :baz 2})")).toEqual(5);
+      expect(evaluateString("(:foo {:bar 3 :foo 5 :baz 2})")).toEqual(5);
     });
     it("should update records", () => {
       expect(evaluateString("{:x 2 | {:x 1}}")).toEqual({ x: 2 });

--- a/packages/delisp-core/src/infer-debug.ts
+++ b/packages/delisp-core/src/infer-debug.ts
@@ -1,0 +1,17 @@
+import { Expression, Typed } from "./syntax";
+import { foldExpr } from "./syntax-utils";
+import { TypeWithWildcards } from "./type-wildcards";
+
+export function typeAnnotate(expr: Expression<Typed>): Expression {
+  return foldExpr(expr, e => {
+    return {
+      node: {
+        tag: "type-annotation",
+        typeWithWildcards: new TypeWithWildcards(e.info.type),
+        value: e
+      },
+      info: {},
+      location: e.location
+    };
+  });
+}

--- a/packages/delisp-core/src/type-printer.ts
+++ b/packages/delisp-core/src/type-printer.ts
@@ -1,4 +1,3 @@
-import { InvariantViolation } from "./invariant";
 import { range } from "./utils";
 import { TApplication, Type, TVar } from "./types";
 import { normalizeRow } from "./type-utils";
@@ -149,8 +148,12 @@ function _printType(
     case "type-variable":
       return normalizeVar({ node: type.node });
     case "empty-row":
+      return "#<empty-row>";
     case "row-extension":
-      throw new InvariantViolation(`Can't print ${type.node.tag} types`);
+      return `(#<row-extend> ${type.node.label} ${_printType(
+        type.node.labelType,
+        normalizeVar
+      )} | ${_printType(type.node.extends, normalizeVar)}})`;
   }
 }
 

--- a/packages/delisp/init.dl
+++ b/packages/delisp/init.dl
@@ -19,17 +19,11 @@
 
 (define >>
   (lambda (outer inner)
-    (lambda (container)
-      (values (inner (outer container))
-              (lambda (value
-                       container)
-                (set outer
-                     (set inner
-                          value
-                          (outer container))
-                     container))))))
-
-(define test
-  (multiple-value-bind (_ change)
-      (:x {:x 10})
-    change))
+    (lambda (outer-container)
+      (multiple-value-bind (inner-container outer-update)
+          (outer outer-container)
+        (multiple-value-bind (value inner-update)
+            (inner inner-container)
+          (values value
+                  (>>> inner-update
+                       outer-update)))))))

--- a/packages/delisp/init.dl
+++ b/packages/delisp/init.dl
@@ -4,23 +4,32 @@
 
 (define over
   (lambda (lens fn x)
-    (set lens (fn (get lens x)) x)))
+    (multiple-value-bind (current change)
+        (lens x)
+      (change (fn current)))))
+
+(define constantly
+  (lambda (x) (lambda (y) x)))
+
+(define set
+  (lambda (lens value container)
+    (over lens
+          (constantly value)
+          container)))
 
 (define >>
   (lambda (outer inner)
-    {:get (lambda (container)
-       (get inner (get outer container)))
-     :set (lambda (value container)
-       (set outer
-            (set inner
-                 value
-                 (get outer container))
-            container))}))
+    (lambda (container)
+      (values (inner (outer container))
+              (lambda (value
+                       container)
+                (set outer
+                     (set inner
+                          value
+                          (outer container))
+                     container))))))
 
-(define ^fst
-  {:get fst
-   :set (lambda (v p) (pair v (snd p)))})
-
-(define ^snd
-  {:get snd
-   :set (lambda (v p) (pair (fst p) v))})
+(define test
+  (multiple-value-bind (_ change)
+      (:x {:x 10})
+    change))


### PR DESCRIPTION
Modify lenses to work with the type signature `(-> x _ (values a (-> b _ y)))`

This means that lenses can be used as functions directly. In that case, the primary value gets returned so they act as simple selectors.

`(:x {:x 50})`

